### PR TITLE
Add support for self-healing connection pools

### DIFF
--- a/src/db/connection.cr
+++ b/src/db/connection.cr
@@ -31,7 +31,11 @@ module DB
     # :nodoc:
     property auto_release : Bool = true
 
+    @created_at : Time
+    getter created_at
+
     def initialize(@context : ConnectionContext)
+      @created_at = Time.utc
       @prepared_statements = @context.prepared_statements?
     end
 
@@ -50,6 +54,9 @@ module DB
       raise DB::Error.new("There is an existing transaction in this connection") if @transaction
       @transaction = true
       create_transaction
+    end
+
+    protected def check
     end
 
     protected def create_transaction : Transaction

--- a/src/db/database.cr
+++ b/src/db/database.cr
@@ -59,6 +59,7 @@ module DB
         @setup_connection.call conn
         conn
       }
+      @pool.start_reaper!
     end
 
     # Run the specified block every time a new connection is established, yielding the new connection

--- a/src/db/driver.cr
+++ b/src/db/driver.cr
@@ -36,6 +36,8 @@ module DB
         checkout_timeout:   params.fetch("checkout_timeout", 5.0).to_f,
         retry_attempts:     params.fetch("retry_attempts", 1).to_i,
         retry_delay:        params.fetch("retry_delay", 1.0).to_f,
+        reaping_frequency:  params.fetch("reaping_frequency", 60.0).to_f,
+        reaping_delay:      params.fetch("reaping_delay", 60.0).to_f,
       }
     end
   end


### PR DESCRIPTION
Resolves an issue I was running into with socket (both TCP and Unix) connections being disconnected by a firewall, docker, or system settings on various hosts (fly.io and render.com were the two ones I tested; fly.io uses TCP sockets and render uses Unix ones). Because those disconnects were server-side, the client wasn't aware that the connections in the pool had become disconnected, so they're still treated as open sockets/connections.

Most pools in various languages handle this with rescuing the failed connection, ejecting it from the pool, and retrying -- this adds latency spikes and in my apps was actually triggering DB::ConnectionLost errors (probably due to retry_attempts + retry_delay not being able to get a successful retry in before timing out, but I'm not entirely certain).

Golang and Java both have ConnectionPools that introduce a TTL for connections and kill them. I initially experimented with that, but killing all idle connections, regardless of their current health, was fairly inefficient and created a large number of unnecessary allocations. 

Instead of going with a TTL-based approach, I implemented an optional "health check" that adapters can add to their Connection class. https://github.com/the-business-factory/crystal-pg/pull/1 pairs with this PR 🍷 🧀 and implements a very simple health check.

In a demo low traffic app @ https://hirobot.app the health check itself has eliminated the disconnects, where earlier attempts at implementing TCP keepalive settings on PG, the server, and the database did not; it appears that some firewall or cluster-level disconnects are prevented by the periodic ACK.

[add-more-instrumentation](https://github.com/the-business-factory/hirobot.app/tree/add-more-instrumentation) is the current state of code running on https://hirobot.app.

---

To replicate these connection errors this in a real-world app:

1) Connect an app in dev, have a database setup with a maximum idle pool of 1, initial pool size of 1, max pool size 1. 

Kill the connection directly in SQL: `SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE pid <> pg_backend_pid() AND state = 'idle' LIMIT 1;` -- this kills a random idle connection, so if you have more current connections, you may need to run it a few times.

Wait a minute after executing that SQL command, then try to visit an endpoint in your app that would trigger a database request. Assuming you've killed all the connections, you should see a DB::ConnectionLost error be raised (true in PG, at the very least).

If you run the same test against this branch with DB params `?reaping_frequency=15.0&reaping_delay=0.0` and an adapter with a health check implemented to test the connection [(PG example)](https://github.com/the-business-factory/crystal-pg/pull/1), the failed connection should be removed from the pool and replaced by a new connection.

---

Relevant other PRs: https://github.com/crystal-lang/crystal-db/pull/109